### PR TITLE
Make wupserver configurable

### DIFF
--- a/common/config_types.h
+++ b/common/config_types.h
@@ -32,6 +32,7 @@ typedef struct
     int noIosReload;
     int launchSysMenu;
     int redNAND;
+    int wupserver;
     int seeprom_red;
     int otp_red;
     int syshaxXml;

--- a/ios_mcp/source/main.c
+++ b/ios_mcp/source/main.c
@@ -24,7 +24,11 @@ int _startMainThread(void)
             drawSplashScreen();
         }
 
-        wupserver_init();
+        if(cfw_config.wupserver)
+        {
+            wupserver_init();
+        }
+
         ipc_init();
     }
     return 0;

--- a/src/cfw_config.c
+++ b/src/cfw_config.c
@@ -82,6 +82,7 @@ void default_config(cfw_config_t * config)
     config->noIosReload = 0;
     config->launchSysMenu = 1;
     config->redNAND = 0;
+    config->wupserver = 1;
     config->seeprom_red = 0;
     config->otp_red = 0;
     config->syshaxXml = 0;
@@ -122,6 +123,8 @@ int read_config(cfw_config_t * config)
                 config->noIosReload = atoi(value);
             else if(strcmp(option, "launchSysMenu") == 0)
                 config->launchSysMenu = atoi(value);
+            else if(strcmp(option, "wupserver") == 0)
+                config->wupserver = atoi(value);
         }
     }
 
@@ -144,6 +147,7 @@ int write_config(cfw_config_t * config)
     fprintf(pFile, "noIosReload=%i\n", config->noIosReload);
     fprintf(pFile, "launchSysMenu=%i\n", config->launchSysMenu);
     fprintf(pFile, "redNAND=%i\n", config->redNAND);
+    fprintf(pFile, "wupserver=%i\n", config->wupserver);
     fprintf(pFile, "seeprom_red=%i\n", config->seeprom_red);
     fprintf(pFile, "otp_red=%i\n", config->otp_red);
     fprintf(pFile, "syshaxXml=%i\n", config->syshaxXml);

--- a/src/menu.c
+++ b/src/menu.c
@@ -47,12 +47,15 @@ struct {
     const char *disabled;
 } selection_options[] =
 {
+    /* Normal settings */
     { "Config view mode", "expert", "default" },
     { "Skip this menu on launch", "on", "off" },
     { "Show launch image", "on", "off" },
     { "Don't relaunch OS", "on", "off" },
     { "Launch System Menu", "on", "off" },
     { "redNAND", "on", "off" },
+
+    /* Expert settings */
     { "SEEPROM redirection", "on", "off" },
     { "OTP redirection", "on", "off" },
     { "Use syshax.xml (coldboothax)", "on", "off" },

--- a/src/menu.c
+++ b/src/menu.c
@@ -36,7 +36,7 @@
 #include "dynamic_libs/socket_functions.h"
 #include "menu.h"
 
-#define MAX_CONFIG_SETTINGS_EXPERT          9
+#define MAX_CONFIG_SETTINGS_EXPERT          10
 #define MAX_CONFIG_SETTINGS_DEFAULT         (MAX_CONFIG_SETTINGS_EXPERT - 3)
 
 #define TEXT_SEL(x, text1, text2)           ((x) ? (text1) : (text2))
@@ -54,6 +54,7 @@ struct {
     { "Don't relaunch OS", "on", "off" },
     { "Launch System Menu", "on", "off" },
     { "redNAND", "on", "off" },
+    { "Start wupserver", "on", "off" },
 
     /* Expert settings */
     { "SEEPROM redirection", "on", "off" },
@@ -171,12 +172,15 @@ int ShowMenu(cfw_config_t * currentConfig)
                     config.redNAND = !config.redNAND;
                     break;
                 case 6:
-                    config.seeprom_red = !config.seeprom_red;
+                    config.wupserver = !config.wupserver;
                     break;
                 case 7:
-                    config.otp_red = !config.otp_red;
+                    config.seeprom_red = !config.seeprom_red;
                     break;
                 case 8:
+                    config.otp_red = !config.otp_red;
+                    break;
+                case 9:
                     config.syshaxXml = !config.syshaxXml;
                     break;
                 default:


### PR DESCRIPTION
This patch set makes wupserver configurable. You can turn it off to avoid being owned over TCP port 1337.